### PR TITLE
Fix resize_debounce_time error in kitty.conf

### DIFF
--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -44,7 +44,7 @@ active_border_color     #BABBF1
 inactive_border_color   #737994
 bell_border_color       #E5C890
 hide_window_decorations yes
-resize_debounce_time 0.05 0.05
+resize_debounce_time 0.05
 confirm_os_window_close 0
 
 # Tab bar


### PR DESCRIPTION
## Fix resize_debounce_time error in kitty.conf

This pull request addresses the "could not convert string to float: '0.05 0.05'" error in the `kitty.conf` file. The issue was caused by an incorrect format in the `resize_debounce_time` configuration. This fix adjusts the line to use the correct format, resolving the error.

![image](https://github.com/lactua/dotfiles/assets/73834838/0468d12a-fcd2-4167-8aab-f684daefc69a)

### Changes:
- Modified the `resize_debounce_time` line in `kitty.conf` to resolve the error.
- Tested the changes to ensure proper functionality.

Please review and merge this pull request. Thank you!
